### PR TITLE
Poetry GitHub actions

### DIFF
--- a/.github/workflows/workflow-all.yml
+++ b/.github/workflows/workflow-all.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.10]
+        python-version: ["3.9", "3.10"]
         poetry-version: [1.1.13]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/workflow-all.yml
+++ b/.github/workflows/workflow-all.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9, 3.10]
         poetry-version: [1.1.13]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -30,7 +30,9 @@ jobs:
       with:
         version: ${{ matrix.poetry-version }}
     - name: poetry in motion
-      run: poetry run pytest
+      run: |
+        poetry install
+        poetry run pytest
 
 # Use a separate flow, as we only want to upload one set of codecov results
   codecov:
@@ -43,12 +45,19 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+    - uses: actions/cache@v2
+      with:
+        path: ~/.local
+        key: poetry-1.1.13-0
     - name: Install poetry
       uses: snok/install-poetry@v1
       with:
         poetry-version: 1.1.13
     - name: Generate coverage report
-      run: poetry run pytest tests --cov=./ --cov-report=xml
+#      run: poetry run pytest tests --cov=./ --cov-report=xml
+      run: |
+        poetry install
+        poetry run pytest
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/workflow-all.yml
+++ b/.github/workflows/workflow-all.yml
@@ -21,7 +21,11 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "${{ matrix.python-version }}"
+    - uses: actions/cache@v2
+      with:
+        path: ~/.local
+        key: poetry-${{ matrix.poetry-version }}-0
     - uses: snok/install-poetry@v1
       with:
         version: ${{ matrix.poetry-version }}

--- a/.github/workflows/workflow-all.yml
+++ b/.github/workflows/workflow-all.yml
@@ -15,7 +15,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10"]
         poetry-version: [1.1.13]
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest]
+#        os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/workflow-all.yml
+++ b/.github/workflows/workflow-all.yml
@@ -29,12 +29,8 @@ jobs:
     - uses: snok/install-poetry@v1
       with:
         version: ${{ matrix.poetry-version }}
-    - name: poetry test
-      run: |
-        poetry --help
     - name: poetry in motion
-      run: |
-        poetry run pytest tests --cov=./ --cov-report=xml
+      run: poetry run pytest
 
 # Use a separate flow, as we only want to upload one set of codecov results
   codecov:
@@ -52,8 +48,7 @@ jobs:
       with:
         poetry-version: 1.1.13
     - name: Generate coverage report
-      run: |
-        poetry run pytest tests --cov=./ --cov-report=xml
+      run: poetry run pytest tests --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/workflow-all.yml
+++ b/.github/workflows/workflow-all.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ~/.local
-        key: poetry-${{ matrix.poetry-version }}-0
+        key: poetry-${{ matrix.poetry-version }}-${{ matrix.os }}-0
     - uses: snok/install-poetry@v1
       with:
         version: ${{ matrix.poetry-version }}
@@ -36,19 +36,25 @@ jobs:
 
 # Use a separate flow, as we only want to upload one set of codecov results
   codecov:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10"]
+        poetry-version: [1.1.13]
+        os: [ubuntu-18.04]
     name: Codecov Workflow
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "${{ matrix.python-version }}"
     - uses: actions/cache@v2
       with:
         path: ~/.local
-        key: poetry-1.1.13-0
+        key: poetry-${{ matrix.poetry-version }}-${{ matrix.os }}-0
     - name: Install poetry
       uses: snok/install-poetry@v1
       with:

--- a/.github/workflows/workflow-all.yml
+++ b/.github/workflows/workflow-all.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install poetry
       uses: snok/install-poetry@v1
       with:

--- a/.github/workflows/workflow-all.yml
+++ b/.github/workflows/workflow-all.yml
@@ -18,12 +18,11 @@ jobs:
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: setup
-      uses: actions/checkout@v3
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-      uses: snok/install-poetry@v1
+    - uses: snok/install-poetry@v1
       with:
         version: ${{ matrix.poetry-version }}
     - name: poetry in motion

--- a/.github/workflows/workflow-all.yml
+++ b/.github/workflows/workflow-all.yml
@@ -18,17 +18,11 @@ jobs:
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - name: setup
+      uses: actions/checkout@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Get full Python version
-      id: full-python-version
-      shell: bash
-      run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-    - name: Install poetry
       uses: snok/install-poetry@v1
       with:
         version: ${{ matrix.poetry-version }}
@@ -42,9 +36,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.10
     - name: Install poetry

--- a/.github/workflows/workflow-all.yml
+++ b/.github/workflows/workflow-all.yml
@@ -25,6 +25,9 @@ jobs:
     - uses: snok/install-poetry@v1
       with:
         version: ${{ matrix.poetry-version }}
+    - name: poetry test
+      run: |
+        poetry --help
     - name: poetry in motion
       run: |
         poetry run pytest tests --cov=./ --cov-report=xml

--- a/.github/workflows/workflow-all.yml
+++ b/.github/workflows/workflow-all.yml
@@ -1,4 +1,4 @@
-name: Python Test
+name: GitHub CI
 on:
   push:
 #on:
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
-        poetry-version: [1.1.4]
+        poetry-version: [1.1.13]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -29,13 +29,12 @@ jobs:
       shell: bash
       run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
     - name: Install poetry
-      uses: abatilo/actions-poetry@v2.0.0
+      uses: snok/install-poetry@v1
       with:
-        poetry-version: ${{ matrix.poetry-version }}
+        version: ${{ matrix.poetry-version }}
     - name: poetry in motion
       run: |
-        python -m poetry install
-        python -m poetry run python -m pytest tests --cov=./ --cov-report=xml
+        poetry run pytest tests --cov=./ --cov-report=xml
 
 # Use a separate flow, as we only want to upload one set of codecov results
   codecov:
@@ -45,16 +44,15 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@master
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Install poetry
-      uses: abatilo/actions-poetry@v2.0.0
+      uses: snok/install-poetry@v1
       with:
-        poetry-version: 1.1.4
+        poetry-version: 1.1.13
     - name: Generate coverage report
       run: |
-        poetry install
         poetry run pytest tests --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
Workflow updated for latest actions. Refined some processing, added caching for poetry. Had to remove windows as an OS as this eas failing to run with:

```
poetry install
  poetry run pytest
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    pythonLocation: C:\hostedtoolcache\windows\Python\[3](https://github.com/garymcwilliams/ggbowlscalendar/actions/runs/3322011317/jobs/5490443504#step:6:3).9.13\x6[4](https://github.com/garymcwilliams/ggbowlscalendar/actions/runs/3322011317/jobs/5490443504#step:6:4)
    PKG_CONFIG_PATH: C:\hostedtoolcache\windows\Python\3.9.13\x64/lib/pkgconfig
    Python_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.9.13\x64
    Python2_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.9.13\x64
    Python3_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.9.13\x64
    VENV: .venv/scripts/activate
poetry: D:\a\_temp\4cbf8196-288f-4212-936b-7727d[5](https://github.com/garymcwilliams/ggbowlscalendar/actions/runs/3322011317/jobs/5490443504#step:6:5)ad1[9](https://github.com/garymcwilliams/ggbowlscalendar/actions/runs/3322011317/jobs/5490443504#step:6:9)04.ps1:2
Line |
   2 |  poetry install
     |  ~~~~~~
     | The term 'poetry' is not recognized as a name of a cmdlet, function, script file, or executable
     | program. Check the spelling of the name, or if a path was included, verify that the path is correct
     | and try again.

```